### PR TITLE
Removed Broken Class Implemenation.

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -12,7 +12,7 @@ var styles = React.StyleSheet.create({
 class PropertyFinderApp extends React.Component {
   render() {
     return (
-      <React.NavigatorIOS
+      <NavigatorIOS
         style={styles.container}
         initialRoute={{
           title: 'Property Finder',


### PR DESCRIPTION
~~Because PropertyFinderApp extends React.Component, returning
React.NavigatorIOS was breaking the router on my system. I figure this would have been noticed and fixed, so perhaps this is a problem exclusively on my own system. If not, this will be helpful to newcomers, and the blog should be updated as well.~~

Refreshing fixed it
